### PR TITLE
WL-3033 Make sure groups update with multiple roles.

### DIFF
--- a/site-manage-group-section-role-helper/pack/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/RoleGroupEventWatcher.java
+++ b/site-manage-group-section-role-helper/pack/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/RoleGroupEventWatcher.java
@@ -21,6 +21,7 @@
 package org.sakaiproject.site.tool.helper.managegroupsectionrole.impl;
 
 // imports
+import java.util.Collection;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.Set;
@@ -46,6 +47,7 @@ import org.sakaiproject.site.api.Group;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.site.util.SiteConstants;
+import org.sakaiproject.site.util.SiteGroupHelper;
 import org.sakaiproject.thread_local.api.ThreadLocalManager;
 
 /**
@@ -236,7 +238,7 @@ public class RoleGroupEventWatcher implements Observer
 								{
 									Set<Member> members = ((Group) g).getMembers();
 									
-									String[] roles = StringUtils.split(roleString, "+");
+									Collection<String> roles = SiteGroupHelper.unpack(roleString);
 									for (String role : roles)
 									{
 										// remove those provided members by role

--- a/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
+++ b/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
@@ -31,6 +31,7 @@ import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.site.util.Participant;
 import org.sakaiproject.site.util.SiteConstants;
+import org.sakaiproject.site.util.SiteGroupHelper;
 import org.sakaiproject.site.util.SiteParticipantHelper;
 import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.tool.api.Tool;
@@ -278,17 +279,11 @@ public class SiteManageGroupSectionRoleHandler {
             	if (group != null)
             	{
             		String roleProviderId = group.getProperties().getProperty(SiteConstants.GROUP_PROP_ROLE_PROVIDERID);
-            		if (roleProviderId != null)
-            		{
-            			if (groupProvider != null)
-            			{
-	            			String[] groupProvidedRoles = groupProvider.unpackId(roleProviderId);
-	            			for(int i=0; i<groupProvidedRoles.length;i++)
-	            			{
-	            				roles.remove(group.getRole(groupProvidedRoles[i]));
-	            			}
-            			}
-            		}
+	            	Collection<String> groupProvidedRoles = SiteGroupHelper.unpack(roleProviderId);
+	            	for(String role: groupProvidedRoles)
+	            	{
+	            		roles.remove(group.getRole(role));
+	            	}
             	}
             }
         }
@@ -882,30 +877,16 @@ public class SiteManageGroupSectionRoleHandler {
 		}
 		return title.trim();
 	}
-    
-    /**
-     * Return a single string representing the provider id list
-     * @param idsList
-     */
-    private String getProviderString(List<String> idsList)
-    {
-    	String[] sArray = new String[idsList.size()];
-		sArray = (String[]) idsList.toArray(sArray);
-		if (groupProvider != null)
-		{
-			return groupProvider.packId(sArray);
-		}
-		else
-		{
-			// simply concat strings
-			StringBuffer rv = new StringBuffer();
-			for(String sArrayString:sArray)
-			{
-				rv.append(" ").append(sArrayString);
-			}
-			return rv.toString();
-		}
-    }
+
+	/**
+	 * Return a single string representing the provider id list
+	 * @param idsList
+	 */
+	private String getProviderString(List<String> idsList)
+	{
+		return SiteGroupHelper.pack(idsList);
+	}
+
     /**
      * Removes a group from the site
      * 
@@ -994,9 +975,9 @@ public class SiteManageGroupSectionRoleHandler {
     }
     
     /**
-     * check whether there is already a group within the site containing the role id
-     * @param roleId
-     * @return
+     * Check whether there is already a group within the site containing the role id
+     * @param roleId This role to check the site groups against. eg: access.
+     * @return <code>true</code> if this a group for this role already exists.
      */
     public boolean existRoleGroup(String roleId)
     {

--- a/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
+++ b/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
@@ -31,6 +31,7 @@ import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.site.util.Participant;
 import org.sakaiproject.site.util.SiteConstants;
+import org.sakaiproject.site.util.SiteGroupHelper;
 import org.sakaiproject.site.util.SiteParticipantHelper;
 import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.tool.api.Tool;
@@ -280,14 +281,12 @@ public class SiteManageGroupSectionRoleHandler {
             		String roleProviderId = group.getProperties().getProperty(SiteConstants.GROUP_PROP_ROLE_PROVIDERID);
             		if (roleProviderId != null)
             		{
-            			if (groupProvider != null)
-            			{
-	            			String[] groupProvidedRoles = groupProvider.unpackId(roleProviderId);
-	            			for(int i=0; i<groupProvidedRoles.length;i++)
+	            			Collection<String> groupProvidedRoles = SiteGroupHelper.unpack(roleProviderId);
+	            			for(String role: groupProvidedRoles)
 	            			{
-	            				roles.remove(group.getRole(groupProvidedRoles[i]));
+	            				roles.remove(group.getRole(role));
 	            			}
-            			}
+
             		}
             	}
             }
@@ -889,22 +888,8 @@ public class SiteManageGroupSectionRoleHandler {
      */
     private String getProviderString(List<String> idsList)
     {
-    	String[] sArray = new String[idsList.size()];
-		sArray = (String[]) idsList.toArray(sArray);
-		if (groupProvider != null)
-		{
-			return groupProvider.packId(sArray);
-		}
-		else
-		{
-			// simply concat strings
-			StringBuffer rv = new StringBuffer();
-			for(String sArrayString:sArray)
-			{
-				rv.append(" ").append(sArrayString);
-			}
-			return rv.toString();
-		}
+		return SiteGroupHelper.pack(idsList);
+	}
     }
     /**
      * Removes a group from the site
@@ -994,9 +979,9 @@ public class SiteManageGroupSectionRoleHandler {
     }
     
     /**
-     * check whether there is already a group within the site containing the role id
-     * @param roleId
-     * @return
+     * Check whether there is already a group within the site containing the role id
+     * @param roleId This role to check the site groups against. eg: access.
+     * @return <code>true</code> if this a group for this role already exists.
      */
     public boolean existRoleGroup(String roleId)
     {

--- a/site-manage-util/util/pom.xml
+++ b/site-manage-util/util/pom.xml
@@ -62,6 +62,11 @@
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
    </dependency>
+   <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+   </dependency>
   </dependencies>
   <build>
     <resources>

--- a/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteConstants.java
+++ b/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteConstants.java
@@ -38,7 +38,11 @@ public class SiteConstants {
 	public static final String SORTED_BY_DISPLAY_ID = "display_id";
 	
 	public static final String GROUP_PROP_WSETUP_CREATED = "group_prop_wsetup_created";
-	
+
+	/**
+	 * This property is used on groups to mark which roles in the site should automatically
+	 * be members of this group.
+	 */
 	public static final String GROUP_PROP_ROLE_PROVIDERID = "group_prop_role_providerid";
 	
 	public static final int SITE_GROUP_TITLE_LIMIT = 99;

--- a/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteConstants.java
+++ b/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteConstants.java
@@ -38,9 +38,13 @@ public class SiteConstants {
 	public static final String SORTED_BY_DISPLAY_ID = "display_id";
 	
 	public static final String GROUP_PROP_WSETUP_CREATED = "group_prop_wsetup_created";
-	
+
+	/**
+	 * This property is used on groups to mark which roles in the site should automatically
+	 * be members of this group.
+	 */
 	public static final String GROUP_PROP_ROLE_PROVIDERID = "group_prop_role_providerid";
-	
+
 	public static final int SITE_GROUP_TITLE_LIMIT = 99;
 
 }

--- a/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteGroupHelper.java
+++ b/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteGroupHelper.java
@@ -64,7 +64,7 @@ public class SiteGroupHelper {
 	 * This packs IDs into a string. It supports empty IDs but not <code>null</code>.
 	 *
 	 * @param ids A Collection of IDs to be packed together.
-	 * @return The packed string containing all the IDs or <code>null</code> if the original colleciton was
+	 * @return The packed string containing all the IDs or <code>null</code> if the original collection was
 	 * <code>null</code>.
 	 * @see #unpack(String)
 	 */

--- a/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteGroupHelper.java
+++ b/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteGroupHelper.java
@@ -1,0 +1,80 @@
+package org.sakaiproject.site.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.regex.Pattern;
+
+/**
+ * Helper for managing groups in a site.
+ *
+ * @author Matthew Buckett
+ */
+public class SiteGroupHelper {
+
+	// The separator when packing ids into a string.
+	static final char SEPARATOR = ',';
+	// The character we use to escape strings.
+	static final char ESCAPE = '\\';
+
+	// String versions to simplify code.
+	static final String ESCAPE_STR = Character.toString(ESCAPE);
+	static final String SEPARATOR_STR = Character.toString(SEPARATOR);
+
+	// Force this class to be a helper.
+	private SiteGroupHelper() {
+	}
+
+	/**
+	 * This unpacks IDs from a string. It supports empty IDs but not <code>null</code>.
+	 *
+	 * @param ids The packed IDs in a string.
+	 * @return A collection of IDs unpacked from the string.
+	 * @see #pack(java.util.Collection)
+	 */
+	public static Collection<String> unpack(String ids) {
+		Collection<String> unpacked = new ArrayList<String>();
+		StringBuilder id = new StringBuilder();
+		boolean inEscape = false;
+		for (int i = 0; i < ids.length(); i++) {
+			if (inEscape) {
+				// We could check that it's a ESCAPE or SEPERATOR here, but we can just be lax.
+				id.append(ids.charAt(i));
+				inEscape = false;
+			} else {
+				switch (ids.charAt(i)) {
+					case ESCAPE:
+						inEscape = true;
+						break;
+					case SEPARATOR:
+						unpacked.add(id.toString());
+						id = new StringBuilder();
+						break;
+					default:
+						id.append(ids.charAt(i));
+				}
+			}
+		}
+		unpacked.add(id.toString());
+		return unpacked;
+	}
+
+	/**
+	 * This packs IDs into a string. It supports empty IDs but not <code>null</code>.
+	 *
+	 * @param ids A Collection of IDs to be packed together.
+	 * @return The packed string containing all the IDs.
+	 * @see #unpack(String)
+	 */
+	public static String pack(Collection<String> ids) {
+		StringBuilder packed = new StringBuilder();
+		String separator = "";
+		for (String id : ids) {
+			packed.append(separator);
+			separator = SEPARATOR_STR; // Actually set it up correctly.
+			packed.append(id
+					.replace(ESCAPE_STR, ESCAPE_STR + ESCAPE_STR)
+					.replace(SEPARATOR_STR, ESCAPE_STR + SEPARATOR_STR));
+		}
+		return packed.toString();
+	}
+}

--- a/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteGroupHelper.java
+++ b/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteGroupHelper.java
@@ -1,0 +1,58 @@
+package org.sakaiproject.site.util;
+
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Helper for managing groups in a site.
+ *
+ * @author Matthew Buckett
+ */
+public class SiteGroupHelper {
+
+	// The separator when packing ids into a string.
+	public static final String SEPARATOR = ",";
+
+	// Force this class to be a helper.
+	private SiteGroupHelper() {
+	}
+
+	/**
+	 * This unpacks IDs from a string. It supports empty IDs but not <code>null</code>.
+	 * @param ids The packed IDs in a string, can be <code>null</code>.
+	 * @return A collection of IDs unpacked from the string.
+	 * @see #pack(java.util.Collection)
+	 */
+	public static Collection<String> unpack(String ids) {
+		Collection<String> unpacked = Collections.<String>emptyList();
+		if (ids != null) {
+			unpacked = Arrays.asList(ids.split(SEPARATOR, -1));
+		}
+		return unpacked;
+	}
+
+	/**
+	 * This packs IDs into a string. It supports empty IDs but not <code>null</code>.
+	 * @param ids A Collection of IDs to be packed together.
+	 * @return The packed string containing all the IDs or <code>null</code> if the original colleciton was
+	 * <code>null</code>.
+	 * @throws IllegalArgumentException if any of the strings contain the separator.
+	 * @see #unpack(String)
+	 */
+	public static String pack(Collection<String> ids) {
+		String packed = null;
+		if (ids != null) {
+			for(String id: ids) {
+				if (id.contains(SEPARATOR)) {
+					throw new IllegalArgumentException(id + " contains the seperator and can't be joined.");
+				}
+			}
+			packed = StringUtils.join(ids, SEPARATOR);
+		}
+		return packed;
+	}
+}

--- a/site-manage-util/util/src/test/org/sakaiproject/site/util/SiteGroupHelperTest.java
+++ b/site-manage-util/util/src/test/org/sakaiproject/site/util/SiteGroupHelperTest.java
@@ -1,0 +1,57 @@
+package org.sakaiproject.site.util;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+import static org.sakaiproject.site.util.SiteGroupHelper.*;
+
+/**
+ * @author Matthew Buckett
+ */
+public class SiteGroupHelperTest {
+
+	@Test
+	public void testPackSimple() {
+		testRoundTrip("A", "B");
+	}
+
+	@Test
+	public void testPackEmpty() {
+		testRoundTrip("", "", "A", "");
+	}
+
+	@Test
+	public void testPackNothing() {
+		testRoundTrip("");
+	}
+
+	@Test
+	public void testPackSeperator() {
+		testRoundTrip(SEPARATOR_STR, "A", SEPARATOR_STR);
+	}
+
+	@Test
+	public void testPackEscape() {
+		testRoundTrip(ESCAPE_STR, "A", ESCAPE_STR);
+	}
+
+	@Test
+	public void testPackEmbedded() {
+		testRoundTrip("Hello", SEPARATOR_STR +"middle"+ SEPARATOR_STR, ESCAPE_STR+"middle"+ESCAPE_STR);
+	}
+
+	@Test
+	public void testPackMess() {
+		testRoundTrip(SEPARATOR_STR+ESCAPE_STR+ESCAPE_STR+SEPARATOR_STR);
+	}
+
+	public void testRoundTrip(String... parts) {
+		Collection<String> source = Arrays.asList(parts);
+		String packed = pack(source);
+		Collection<String> unpacked = unpack(packed);
+		assertEquals("Packed value was : "+ packed +"\n", source, unpacked);
+	}
+}

--- a/site-manage-util/util/src/test/org/sakaiproject/site/util/SiteGroupHelperTest.java
+++ b/site-manage-util/util/src/test/org/sakaiproject/site/util/SiteGroupHelperTest.java
@@ -1,0 +1,59 @@
+package org.sakaiproject.site.util;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+import static org.sakaiproject.site.util.SiteGroupHelper.*;
+
+/**
+ * @author Matthew Buckett
+ */
+public class SiteGroupHelperTest {
+
+	@Test
+	public void testRoundTripSimple() {
+		testRoundTrip("A", "B");
+	}
+
+	@Test
+	public void testRoundTripEmpty() {
+		testRoundTrip("", "", "A", "");
+	}
+
+	@Test
+	public void testRoundTripNothing() {
+		testRoundTrip("");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testRoundTripSeperator() {
+		testRoundTrip(SEPARATOR, "A", SEPARATOR);
+	}
+
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testRoundTripEmbedded() {
+		testRoundTrip("Hello", SEPARATOR +"middle"+ SEPARATOR );
+	}
+
+	public void testRoundTrip(String... parts) {
+		Collection<String> source = Arrays.asList(parts);
+		String packed = pack(source);
+		Collection<String> unpacked = unpack(packed);
+		assertEquals(source, unpacked);
+	}
+
+	@Test
+	public void testPackNull() {
+		assertNull(pack(null));
+	}
+
+	@Test
+	public void testUnpackNull() {
+		assertEquals(Collections.emptyList(), unpack(null));
+	}
+}


### PR DESCRIPTION
This fix has the limitation that role cannot contain a comma. This is not specified anywhere in the documentation, but should be the case.
