### PR TITLE
WL-3338 Correct new site workflow from portal.

### DIFF
--- a/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -5127,21 +5127,20 @@ public class SiteAction extends PagedResourceActionII {
 
 		// start clean
 		cleanState(state);
-		
 
-		if (state.getAttribute(STATE_INITIALIZED) == null) {
-			state.setAttribute(STATE_OVERRIDE_TEMPLATE_INDEX, "1");
-		} else {
-			List siteTypes = (List) state.getAttribute(STATE_SITE_TYPES);
-			if (siteTypes != null) 
-			{
-				state.setAttribute(STATE_TEMPLATE_INDEX, "1");
-			} 
+		List siteTypes = (List) state.getAttribute(STATE_SITE_TYPES);
+		if (siteTypes != null)
+		{
+			state.setAttribute(STATE_TEMPLATE_INDEX, "1");
 		}
 		if (canChooseAdminSite(data, state)) {
 			state.setAttribute(STATE_TEMPLATE_INDEX, "63");
 		} else {
 			doSite_selectAdmin(state, params);
+		}
+
+		if (state.getAttribute(STATE_INITIALIZED) == null) {
+			state.setAttribute(STATE_OVERRIDE_TEMPLATE_INDEX, state.getAttribute(STATE_TEMPLATE_INDEX));
 		}
 	}
 	


### PR DESCRIPTION
When being called from the portal dropdown we were starting the new site workflow with the selection of the site type, rather than the selection of the administration site. This fixes that issue so we get the correct screen when creating new site.
