### PR TITLE
Wl-3353 Don’t NPE when bean hasn’t run init()

### DIFF
--- a/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
+++ b/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
@@ -1304,6 +1304,11 @@ public class SiteAddParticipantHandler {
 	public enum ConfigOption{ EXTERNAL_PARTICIPANTS };
 	
 	public boolean isEnabled(ConfigOption option) {
+		// This is a hack because sometimes this bean is wrongly re-used between requests.
+		// In a previous request it was reset and then this method is called and the site is null.
+		if (site == null) {
+			init();
+		}
 		if(ConfigOption.EXTERNAL_PARTICIPANTS.equals(option)) {
 			// Check enabled serverwide first
 			boolean externalUsers = serverConfigurationService.getBoolean("nonOfficialAccount", true);


### PR DESCRIPTION
When you add a participant for the second time RSF seems to wrongly re-use a object from a previous request. This was causing a NPE. Fixing RSF is hard and so this is just a quick hack.
