### PR TITLE
WL-3631 Allow site titles to be editable again.

### DIFF
--- a/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -8115,11 +8115,11 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 	 */
 	private boolean siteTitleEditable(SessionState state, String site_type) {
 		boolean newSite = getStateSite(state) == null;
-		boolean nonEditSiteType = site_type != null
+		boolean editableSiteType = site_type != null
 				&& ((state.getAttribute(TITLE_NOT_EDITABLE_SITE_TYPE) != null
 				&& !((List) state.getAttribute(TITLE_NOT_EDITABLE_SITE_TYPE)).contains(site_type)));
 		boolean hasHelperTitle = state.getAttribute(SiteHelper.SITE_CREATE_SITE_TITLE) != null;
-		return !(hasHelperTitle) && (newSite || !nonEditSiteType);
+		return !(hasHelperTitle) && (newSite || editableSiteType);
 	}
 	
 	/**


### PR DESCRIPTION
In merging changes to Sakai 10 we stopped site titles from being editable. It was just an error in the logic.
