### PR TITLE
WL-3609 Change the permissions when disabling tools.

### DIFF
--- a/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/impl/SitePageEditHandler.java
+++ b/pageorder/tool/src/java/org/sakaiproject/site/tool/helper/order/impl/SitePageEditHandler.java
@@ -1,19 +1,14 @@
 package org.sakaiproject.site.tool.helper.order.impl;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 
+import org.apache.commons.lang.StringUtils;
+import org.sakaiproject.authz.api.*;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.event.cover.EventTrackingService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
+import org.sakaiproject.exception.SakaiException;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.site.api.ToolConfiguration;
@@ -38,6 +33,7 @@ public class SitePageEditHandler {
     public ToolManager toolManager;
     public SessionManager sessionManager;
     public ServerConfigurationService serverConfigurationService;
+    public AuthzGroupService authzGroupService;
     private Map<String, SitePage> pages;
     public String[] selectedTools = new String[] {};
     private Set<String> unhideables;
@@ -55,6 +51,7 @@ public class SitePageEditHandler {
     private final String PORTAL_VISIBLE = "sakai-portal:visible";
     private final String TOOL_CFG_MULTI = "allowMultiple";
     private final String SITE_UPD = "site.upd";
+    private final String SITE_VISIT = "site.visit";
     private final String HELPER_ID = "sakai.tool.helper.id";
     private final String UNHIDEABLES_CFG = "poh.unhideables";
     private final String UNEDITABLES_CFG = "poh.uneditables";
@@ -387,23 +384,18 @@ public class SitePageEditHandler {
      * @return true if users with out site.upd can see the page
      */
     public boolean isEnabled(SitePage page) {
-        List<ToolConfiguration> tools = page.getTools();
-        Iterator<ToolConfiguration> iPt = tools.iterator();
-
-        boolean visible = false;
-        while( !visible && iPt.hasNext() ) 
-        {
-            ToolConfiguration placement = iPt.next();
-            Properties roleConfig = placement.getConfig();
-            String roleList = roleConfig.getProperty(TOOL_CFG_FUNCTIONS);
-
-            if (roleList == null || !(roleList.indexOf(SITE_UPD) > -1)) {
-                visible = true;
+        Set<Role> roles = getRolesWithout(page.getContainingSite(), SITE_UPD);
+        // Should only have non site.upd roles now.
+        // Now check to see if these roles have the permission listed in the functions require for the tool.
+        List<String> permissions = getRequiredPermissions(page);
+        for (String permission : permissions) {
+            for (Role role : roles) {
+                if (role.isAllowed(permission)) {
+                    return true; // If any one of the permissions is allows for any role.
+                }
             }
-            
         }
-        
-        return visible;
+        return false;
     }
     
     /**
@@ -455,14 +447,36 @@ public class SitePageEditHandler {
     }
 
     /**
-     * Can the page be disabled?
-     * @param page The SitePage that in question.
+     * Can the page be disabled? We don't allow disabling if there is more than one tool on the page or
+     * if there are no required functions listed in functions.require. We need just one tool so that we don't
+     * accidentally disable multiple tools by disabling the home tool.
+     *
+     * @param page The SitePage that is in question.
      * @return <code>true</code> if the page can be disabled.
      * @see #DISABLE_ENABLED_CFG
      */
     public boolean allowDisable(SitePage page) {
-        return serverConfigurationService.getBoolean(DISABLE_ENABLED_CFG, true) && allowsHide(page);
 
+        if (!(serverConfigurationService.getBoolean(DISABLE_ENABLED_CFG, true))) {
+            return false;
+        }
+        List<String> permissions = getRequiredPermissions(page);
+        return !(permissions.isEmpty() || permissions.contains(SITE_UPD) || permissions.contains(SITE_VISIT));
+    }
+
+    private List<String> getRequiredPermissions(SitePage page) {
+        List<ToolConfiguration> tools = page.getTools();
+        if (tools.size() == 1) {
+            // Only if there is one
+            ToolConfiguration toolConfiguration = tools.get(0);
+            String functions = toolConfiguration.getConfig().getProperty(TOOL_CFG_FUNCTIONS);
+            if (functions != null && functions.length() > 0) {
+                List<String> permissions = Arrays.asList(StringUtils.split(functions, ','));
+                return permissions;
+            }
+        }
+        // Don't use Collections.EMPTY_LIST as it needs to be mutable.
+        return new ArrayList<String>();
     }
  
     /**
@@ -472,7 +486,7 @@ public class SitePageEditHandler {
      * @return true for sucess, false for failuer
      * @throws IdUnusedException, PermissionException
      */
-    public boolean disablePage(String pageId) throws IdUnusedException, PermissionException {
+    public boolean disablePage(String pageId) throws SakaiException {
         EventTrackingService.post(
             EventTrackingService.newEvent(PAGE_DISABLE, "/site/" + site.getId() +
                                          "/page/" + pageId, false));
@@ -486,7 +500,7 @@ public class SitePageEditHandler {
      * @return true for sucess, false for failuer
      * @throws IdUnusedException, PermissionException
      */
-    public boolean enablePage(String pageId) throws IdUnusedException, PermissionException {
+    public boolean enablePage(String pageId) throws SakaiException {
         EventTrackingService.post(
             EventTrackingService.newEvent(PAGE_ENABLE, "/site/" + site.getId() +
                                          "/page/" + pageId, false));
@@ -502,7 +516,7 @@ public class SitePageEditHandler {
      * @return true for sucess, false for failuer
      * @throws IdUnusedException, PermissionException
      */
-    public boolean hidePage(String pageId) throws IdUnusedException, PermissionException {
+    public boolean hidePage(String pageId) throws SakaiException {
         EventTrackingService.post(
             EventTrackingService.newEvent(PAGE_HIDE, "/site/" + site.getId() +
                                          "/page/" + pageId, false));
@@ -517,7 +531,7 @@ public class SitePageEditHandler {
      * @return true for sucess, false for failuer
      * @throws IdUnusedException, PermissionException
      */
-    public boolean showPage(String pageId) throws IdUnusedException, PermissionException {
+    public boolean showPage(String pageId) throws SakaiException {
         EventTrackingService.post(
             EventTrackingService.newEvent(PAGE_SHOW, "/site/" + site.getId() +
                                          "/page/" + pageId, false));
@@ -533,8 +547,8 @@ public class SitePageEditHandler {
      * @return true for sucess, false for failuer
      * @throws IdUnusedException, PermissionException
      */
-    private boolean pageVisibilityHelper(String pageId, boolean visible, boolean enabled) 
-                                throws IdUnusedException, PermissionException{
+    private boolean pageVisibilityHelper(String pageId, boolean visible, boolean enabled)
+            throws SakaiException {
 
         if (site == null) {
             init();
@@ -548,7 +562,6 @@ public class SitePageEditHandler {
         while( iterator.hasNext() ) {
             ToolConfiguration placement = iterator.next();
             Properties roleConfig = placement.getPlacementConfig();
-            String roleList = roleConfig.getProperty(TOOL_CFG_FUNCTIONS);
             String visibility = roleConfig.getProperty(PORTAL_VISIBLE);
             boolean saveChanges = false;
             
@@ -558,40 +571,60 @@ public class SitePageEditHandler {
             } else if ( ( !"false".equals(visibility) )  && !visible )  {
                 visibility = "false";
                 saveChanges = true;
-            } 
-
-            if (roleList == null) {
-                roleList = "";
-            }
-            if (!(roleList.indexOf(SITE_UPD) > -1) && !enabled) {
-                if (roleList.length() > 0) {
-                    roleList += ",";
-                }
-                roleList += SITE_UPD;
-                saveChanges = true;
-            }
-            else if (enabled) {
-                roleList = roleList.replaceAll("," + SITE_UPD, "");
-                roleList = roleList.replaceAll(SITE_UPD, "");
-                saveChanges = true;
             }
             
             if (saveChanges) {
-                roleConfig.setProperty(TOOL_CFG_FUNCTIONS, roleList);
                 if ( visibility != null ) {
                     roleConfig.setProperty(PORTAL_VISIBLE, visibility);
                 }
-
                 placement.save();
-                
-                siteService.save(site);
             }
             
         }
-        
+        try {
+            AuthzGroup authzGroup =  authzGroupService.getAuthzGroup(site.getReference());
+            List<String> permissions = getRequiredPermissions(page);
+            if (!(permissions.isEmpty())) {
+                // We never change SITE_UPD at all.
+                permissions.remove(SITE_UPD);
+                permissions.remove(SITE_VISIT);
+                Set<Role> roles = getRolesWithout(authzGroup, SITE_UPD);
+
+
+                for (Role role : roles) {
+                    if (enabled) {
+                        role.allowFunctions(permissions);
+                    } else {
+                        role.disallowFunctions(permissions);
+                    }
+                }
+                // Need to save the authz as saving the site doesn't save the authzgroup (when changing permissions)
+                authzGroupService.save(authzGroup);
+            }
+        } catch (GroupNotDefinedException e) {
+            throw new SakaiException(e);
+        } catch (AuthzPermissionException e) {
+            throw new SakaiException(e);
+        }
+
+
+
         return true;
     }
-    
+
+    private Set<Role> getRolesWithout(AuthzGroup authzGroup, String function) {
+        // Gets the roles
+        Set<Role> roles = authzGroup.getRoles();
+        Iterator<Role> roleIterator = roles.iterator();
+        while (roleIterator.hasNext()) {
+            Role role = roleIterator.next();
+            if (role.isAllowed(function)) {
+                roleIterator.remove();
+            }
+        }
+        return roles;
+    }
+
     /**
      * Adds a new single tool page to the current site
      * @param toolId

--- a/pageorder/tool/src/webapp/WEB-INF/requestContext.xml
+++ b/pageorder/tool/src/webapp/WEB-INF/requestContext.xml
@@ -33,5 +33,6 @@
     <property name="toolManager" ref="org.sakaiproject.tool.api.ToolManager" />
     <property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager" />
     <property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
+    <property name="authzGroupService" ref="org.sakaiproject.authz.api.AuthzGroupService"/>
   </bean>
 </beans>


### PR DESCRIPTION
When you disable a tool we change the permissions so that all roles without site.upd no longer have permission to use the tool. Todo this a tool needs to have registered it’s required functions. Because not all tools register required functions not all tools can be disabled any more.

Changing the permissions has the added benefit that it also stops users from accessing the content through web services (/direct), synoptic tools in the Home page and synoptic tools in My Workspace.
