### PR TITLE
WL-3712 Don’t remove all other aliases.

### DIFF
--- a/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -10785,32 +10785,20 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 						addAlert(state, rb.getString("java.addalias"));
 					} else {
 						try {
-							// first, clear any alias set to this channel
-							AliasService.removeTargetAliases(channelReference); // check
-							// to
-							// see
-							// whether
-							// the
-							// alias
-							// has
-							// been
-							// used
-							try {
-								String target = AliasService.getTarget(alias);
-								boolean targetsThisSite = site.getReference().equals(target);
-								if (!(targetsThisSite)) {
-									addAlert(state, rb.getString("java.emailinuse") + " ");
-								}
-							} catch (IdUnusedException ee) {
-								try {
-									AliasService.setAlias(alias,
-											channelReference);
-								} catch (IdUsedException exception) {
-								} catch (IdInvalidException exception) {
-								} catch (PermissionException exception) {
-								}
+							String target = AliasService.getTarget(alias);
+							boolean targetsThisSite = site.getReference().equals(target) ||
+									channelReference.equals(target);
+							if (!(targetsThisSite)) {
+								addAlert(state, rb.getString("java.emailinuse") + " ");
 							}
-						} catch (PermissionException exception) {
+						} catch (IdUnusedException ee) {
+							try {
+								AliasService.setAlias(alias,
+										channelReference);
+							} catch (IdUsedException exception) {
+							} catch (IdInvalidException exception) {
+							} catch (PermissionException exception) {
+							}
 						}
 					}
 				}


### PR DESCRIPTION
When we’re checking the email archive alias don’t remove the all the other aliases to the site/mailarchive. Although removing them all keeps things tidy it doesn’t allow people to create new email archive aliases and having multiple aliases is useful as you can ask people to use the new alias without having the old one bounce straight away.
