### PR TITLE
WL-3887 Include bring site message when duplicating.

### DIFF
--- a/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -987,6 +987,7 @@ sitdup.dupaclanoncourse	= Duplicating a site will create a new site with content
 sitdup.dupsit    = Duplicate site
 sitdup.dupsit2   = Duplicated site
 sitdup.hasbeedup = has been created.
+sitdup.bring = Use 'Bring Site' to attach it to a suitable place in your unit's hierarchy.
 sitdup.sitti    = Site Title
 sitdup.duptit   = Retain Resources file storage quota?
 sitdup.curquot  = Currently set to 

--- a/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -1987,7 +1987,10 @@ public class SiteAction extends PagedResourceActionII {
 				
 				if (state.getAttribute(SITE_DUPLICATED) != null) {
 					String flashNotifMsg = "<a title=\""+state.getAttribute(SITE_DUPLICATED_NAME) +"\" href=\""+state.getAttribute(STATE_DUPE_SITE_URL)+"\" target=\"_top\">"+state.getAttribute(SITE_DUPLICATED_NAME)+"</a>";
-					addFlashNotif(state, rb.getString("sitdup.dupsit") + " " + flashNotifMsg + " " + rb.getString("sitdup.hasbeedup"));
+					addFlashNotif(state, rb.getString("sitdup.dupsit") + " "
+						+flashNotifMsg + " " + rb.getString("sitdup.hasbeedup") + " "
+						+rb.getString("sitdup.bring")
+					);
 				}
 				state.removeAttribute(SITE_DUPLICATED);
 				state.removeAttribute(SITE_DUPLICATED_NAME);


### PR DESCRIPTION
This was missing in the original change, this shouldn’t go back to Sakai as it’s an Oxford specific thing.
