### PR TITLE
WL-4037: Don't show the Remove button if it's a suspended group

### DIFF
--- a/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
+++ b/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
@@ -522,9 +522,10 @@ function printPreview(target){
 		<table>
 		#if ($providedGroups.size() > 0)
 			#foreach ($group in $providedGroups)
-				#if (!$group.name.contains("(suspended)"))
-					<tr>
-						<td>$validator.escapeHtml($group.name)</td>
+				<tr>
+					<td>$validator.escapeHtml($group.name)</td>
+##					don't show the Remove button if it's suspended group - it gets removed by removing the corrsponding non-suspended group
+					#if (!$group.name.contains("(suspended)"))
 						<td>
 							#if ($allowUpdateSiteMembership)
 							<form name="removeGroupForm" class="inlineForm" method="post" action="#toolForm("SiteAction")">
@@ -537,8 +538,8 @@ function printPreview(target){
 							</form>
 							#end
 						</td>
-					</tr>
-				#end
+					#end
+				</tr>
 			#end
 		#else
 			<tr>


### PR DESCRIPTION
It gets removed by removing the corresponding non-suspended group
