### PR TITLE
WL-3743 Added 'search Users' textbox in Site Info.

### DIFF
--- a/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -1257,3 +1257,4 @@ softly.deleted.already=One or more of the sites you selected are already marked 
 softly.deleted.already2=The site you chose has not been marked for deletion so no action is necessary.
 softly.deleted.restore.nopermission=You cannot restore that site as you do not have permission.
 softly.deleted.invalidsite=You cannot restore that site as it no longer exists.
+sitegen.siteinfolist.searchUser=Search

--- a/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -1945,7 +1945,8 @@ public class SiteAction extends PagedResourceActionII {
 			 */
 			// put the link for downloading participant
 			putPrintParticipantLinkIntoContext(context, data, site);
-			
+			context.put("searchString", state.getAttribute(STATE_SEARCH));
+			context.put("form_search", FORM_SEARCH);
 			context.put("userDirectoryService", UserDirectoryService
 					.getInstance());
 			try {
@@ -4667,6 +4668,34 @@ public class SiteAction extends PagedResourceActionII {
 		state.removeAttribute(STATE_SEARCH);
 
 	} // doSite_search_clear
+
+	public void doUser_search(RunData data, Context context) {
+		SessionState state = ((JetspeedRunData) data)
+				.getPortletSessionState(((JetspeedRunData) data).getJs_peid());
+
+		// read the search form field into the state object
+		String search = StringUtils.trimToNull(Validator.escapeHtml(data.getParameters().getString(FORM_SEARCH)));
+
+		// set the flag to go to the prev page on the next list
+		if (search == null) {
+			state.removeAttribute(STATE_SEARCH);
+		} else {
+			state.setAttribute(STATE_SEARCH, search);
+		}
+
+	} // doUser_search
+
+	/**
+	 * Handle a Search Clear request.
+	 */
+	public void doUser_search_clear(RunData data, Context context) {
+		SessionState state = ((JetspeedRunData) data)
+				.getPortletSessionState(((JetspeedRunData) data).getJs_peid());
+
+		// clear the search
+		state.removeAttribute(STATE_SEARCH);
+
+	} // doUser_search_clear
 
 	/**
 	 * 
@@ -10620,6 +10649,19 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 		}
 
 		Collection participants = SiteParticipantHelper.prepareParticipants(siteId, providerCourseList);
+		//check for search user attribute in the state
+		String search = (String)state.getAttribute(STATE_SEARCH);
+		if(search != null && (participants.size() > 0)){
+			for(Object object : participants){
+				Participant participant = (Participant)object;
+				//if search term is in the display name or in display Id, add into the list
+				if(participant.getDisplayName().contains(search) || participant.getDisplayId().contains(search)){
+					members.add(participant);
+				}
+			}
+			state.setAttribute(STATE_PARTICIPANT_LIST, members);
+			return members;
+		}
 		state.setAttribute(STATE_PARTICIPANT_LIST, participants);
 
 		return participants;

--- a/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
+++ b/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
@@ -111,6 +111,12 @@
 		});
 	  });
 	  
+	//method called to do search for the participant
+	function doSearch(url){
+		var searchText = $("#search").val();
+		location = url + "&search=" + searchText;
+		return true;
+	}
 	function toggleSelectAll(caller, elementName)
     {
 		var newValue = caller.checked;
@@ -578,6 +584,14 @@ function printPreview(target){
 								#end 
 							#end 
 						</a>
+						<span class="site-searchbox">
+							<label for="$form_search" class="skip">$tlang.getString('list.search')</label>
+							<input size="10"  value="$validator.escapeHtml($!searchString)" name="$form_search" id="$form_search" type="text" class="searchField"  />
+							<input type="button" value="$tlang.getString('sitegen.siteinfolist.searchUser')" onclick="doSearch('#toolLink($action "doUser_search")');" />
+							#if (($!searchString) && (!$searchString.equals("")))
+								<input type="button" class="button" value="$tlang.getString("list.cls")" onclick="location = '#toolLink($action "doUser_search_clear")';return false;" />
+							#end
+						</span>
 					</th>
 					#if ($hasProviderSet)
 						<th id="coursename">


### PR DESCRIPTION
Added Search input and clear search in the chef_site-siteInfo-list.vm.
If search word is in session state then Participant List is filtered for
the search term in each Participant's displayName and displayId.
Corrected the position of search box in the participant's table.
This pull request is linked to https://github.com/ox-it/wl-reference/pull/125
