### PR TITLE
WL-3743 Search User in Site-info works for paged results.

### DIFF
--- a/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -4683,6 +4683,8 @@ public class SiteAction extends PagedResourceActionII {
 		if (search == null) {
 			state.removeAttribute(STATE_SEARCH);
 		} else {
+			//search item is present, if the result was paged clear the top position from the state
+			state.removeAttribute(STATE_TOP_PAGE_MESSAGE);
 			state.setAttribute(STATE_SEARCH, search);
 		}
 


### PR DESCRIPTION
In Site-Info if participants list is paged and search term is present then
cleared the value of 'STATE_TOP_PAGE_MESSAGE' attribute from the state.
